### PR TITLE
Added error handling to GetNextEvent

### DIFF
--- a/Spartacus/ProcMon/ProcMonPML.cs
+++ b/Spartacus/ProcMon/ProcMonPML.cs
@@ -53,7 +53,17 @@ namespace Spartacus.ProcMon
 
         public PMLEvent? GetNextEvent()
         {
-            return GetEvent(currentEventIndex++);
+            PMLEvent nextEvent = new PMLEvent();
+            try
+            {
+                nextEvent = (PMLEvent)GetEvent(currentEventIndex++);
+            }
+            catch
+            {
+                Logger.Debug("An event was invalid and thrown out.", true, true);
+            }
+
+            return nextEvent;
         }
 
         public PMLEvent? GetEvent(UInt32 eventIndex)


### PR DESCRIPTION
Ran into a situation where a PML file had one line that had unreadable or invalid data and it was causing Spartacus to fail. Adding this change worked for me. It just throws out invalid events with a debug message indicating that it did so.