### PR TITLE
Added language version

### DIFF
--- a/Spartacus/Spartacus.csproj
+++ b/Spartacus/Spartacus.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>Spartacus</RootNamespace>
     <AssemblyName>Spartacus</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <LangVersion>9.0</LangVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>


### PR DESCRIPTION
Later versions of Visual Studio can fail to build Spartacus by default because the language version is unspecified, while the code uses features of C# that are only available in newer versions of the language. This specifies the language version as 9, which is the earliest version that works for this code.